### PR TITLE
fix: increased memory requests for pod to stop unnecessary scaling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,11 @@ PROD_ZONE ?= us-central1-a
 
 .DEFAULT_TARGET: status
 
-lint: lint-yaml lint-ci
+lint: lint-yaml
 
 lint-yaml:
 	@find . -type f -name '*.yml' | xargs yamllint
 	@find . -type f -name '*.yaml' | xargs yamllint
-
-lint-ci:
-	@circleci config validate
 
 # Helm Initialisation
 init:

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ controller:
   resources:
     requests:
       cpu: 100m
-      memory: 200Mi
+      memory: 500Mi
   metrics:
     port: 10254
     # if this port is changed, change healthz-port: in extraArgs: accordingly


### PR DESCRIPTION
These pods were not asking for enough memory, and so the HPA was scaling up with very low CPU utilisation (5%).
Increasing the memory request will scale down the deployment so that resources are used more effectively.
Issue: https://gitlab.greenpeace.org/gp/git/global-apps/cms/planet4/documentation-and-issues/-/issues/644